### PR TITLE
Extend AppTestCase in EmailQueue plugin tests

### DIFF
--- a/Test/Case/Console/Command/SenderShellTest.php
+++ b/Test/Case/Console/Command/SenderShellTest.php
@@ -2,12 +2,13 @@
 
 App::uses('SenderShell', 'EmailQueue.Console/Command');
 App::uses('CakeEmail', 'Network/Email');
+App::uses('AppTestCase', 'TestSuite');
 
 /**
  * SenderShell Test Case
  *
  */
-class SenderShellTest extends CakeTestCase {
+class SenderShellTest extends AppTestCase {
 
 /**
  * Fixtures

--- a/Test/Case/Model/EmailQueueTest.php
+++ b/Test/Case/Model/EmailQueueTest.php
@@ -1,11 +1,12 @@
 <?php
 App::uses('EmailQueue', 'EmailQueue.Model');
+App::uses('AppTestCase', 'TestSuite');
 
 /**
  * EmailQueue Test Case
  *
  */
-class EmailQueueTest extends CakeTestCase {
+class EmailQueueTest extends AppTestCase {
 
 /**
  * Fixtures


### PR DESCRIPTION
EmailQueue Plugin tests were extending CakeTestCase
rather than AppTestCase which meant the wrong
DB was being used under certain conditions.

[#182732309]